### PR TITLE
fix: dagster 1.13 compatibility and flaky serdes under xdist

### DIFF
--- a/src/kedro_dagster/cli/commands.py
+++ b/src/kedro_dagster/cli/commands.py
@@ -132,14 +132,15 @@ if DAGSTER_VERSION >= (1, 10, 6):
         """
         # Discover the available dg commands from the official CLI entrypoint factory
         dg_root: click.Group = create_dg_cli()
-        dg_command_names = list(dg_root.commands.keys())
+        dg_ctx = click.Context(dg_root)
+        dg_command_names = dg_root.list_commands(dg_ctx)
 
         # Skip commands we already expose explicitly in this group
         existing = set(getattr(dagster_commands, "commands", {}).keys())
         wrapped_command_names = [cmf for cmf in dg_command_names if cmf not in existing]
 
         for cmd_name in wrapped_command_names:
-            cmd_obj = dg_root.commands[cmd_name]
+            cmd_obj = dg_root.get_command(dg_ctx, cmd_name)
 
             def _callback_factory(name: str) -> Any:
                 """Return a Click callback that proxies to 'dg <name>'."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import importlib.metadata as _ilmd
 from collections.abc import Callable
 from pathlib import Path
 
+import dagster_shared.serdes.serdes as _serdes_mod
 import kedro.framework.session.session as _kedro_session_mod
 from kedro.framework import project as _kedro_project
 from pytest import fixture
@@ -28,6 +29,21 @@ from .scenarios.kedro_projects import (
     options_spaceflights_quickstart,
 )
 from .scenarios.project_factory import KedroProjectOptions, build_kedro_project_scenario
+
+# Under pytest-xdist with coverage, dagster's serdes @whitelist_for_serdes
+# decorator can fire twice for the same class, causing a SerdesUsageError.
+# Monkey-patch WhitelistMap.register_object to silently skip duplicates.
+_original_register_object = _serdes_mod.WhitelistMap.register_object
+
+
+def _idempotent_register_object(self, name, object_class, serializer_class, storage_name=None, **kwargs):
+    deserializer_name = storage_name or name
+    if deserializer_name in self.object_deserializers:
+        return
+    _original_register_object(self, name, object_class, serializer_class, storage_name=storage_name, **kwargs)
+
+
+_serdes_mod.WhitelistMap.register_object = _idempotent_register_object
 
 
 @fixture(scope="session")


### PR DESCRIPTION
## Description

Fix CI failures caused by dagster 1.13 lazy CLI loading and flaky serdes registration under pytest-xdist.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Dagster 1.13 changed `DgCliGroup` to use lazy command loading, leaving the `.commands` dict empty. This broke `_register_dg_commands()` which accessed `.commands` directly, causing 7 test_cli.py failures across all CI jobs.

Separately, under pytest-xdist with coverage, dagster's `@whitelist_for_serdes` decorator can fire twice for the same class, causing intermittent `SerdesUsageError`.

Fixes #109

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
