### PR TITLE
ci: add Python 3.14 support

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -10,7 +10,7 @@ github_username: stateful-y
 include_actions: True
 include_examples: False
 license: Apache-2.0
-max_python_version: '3.13'
+max_python_version: '3.14'
 min_python_version: '3.11'
 package_name: kedro_dagster
 project_name: Kedro-Dagster

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:

--- a/.github/workflows/tests-versions.yml
+++ b/.github/workflows/tests-versions.yml
@@ -30,6 +30,11 @@ jobs:
         os: [ubuntu-latest]
         kedro_spec: ["kedro>=1.0,<2.0"]
         dagster_spec: ["dagster>=1.10,<1.11", "dagster>=1.11,<1.12", "dagster>=1.12,<1.13",]
+        exclude:
+          - python-version: "3.14"
+            dagster_spec: "dagster>=1.10,<1.11"
+          - python-version: "3.14"
+            dagster_spec: "dagster>=1.11,<1.12"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/tests-versions.yml
+++ b/.github/workflows/tests-versions.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest]
         kedro_spec: ["kedro>=1.0,<2.0"]
         dagster_spec: ["dagster>=1.10,<1.11", "dagster>=1.11,<1.12", "dagster>=1.12,<1.13",]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         # Draft PRs: Ubuntu only, min+max Python versions
         # Ready PRs: All OS, min+max Python versions
         os: ${{ github.event.pull_request.draft && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest", "windows-latest", "macos-latest"]') }}
-        python-version: ["3.11", "3.13"]
+        python-version: ["3.11", "3.14"]
 
     steps:
       - name: Checkout code
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.14"
   jobs:
     pre_create_environment:
       # Install uv via asdf (or system package) before creating the venv

--- a/docs/pages/how-to/contribute.md
+++ b/docs/pages/how-to/contribute.md
@@ -257,11 +257,11 @@ Follow these conventions when writing tests:
 
 The CI pipeline uses a two-tier testing strategy optimized for fast feedback:
 
-1. **Fast tests** (`test-fast` job): Runs on minimum and maximum Python versions (3.11, 3.13) only:
+1. **Fast tests** (`test-fast` job): Runs on minimum and maximum Python versions (3.11, 3.14) only:
     - **Draft PRs**: Ubuntu only - Quick feedback in ~2-3 minutes
     - **Ready PRs/Main**: All OS - Ubuntu, Windows, macOS - Cross-platform validation
 
-2. **Full test suite** (`test-full` job): Runs all tests (fast + slow + integration) on Ubuntu across all Python versions (3.11-3.13) when the PR is not in draft mode or on the main branch. This comprehensive validation includes coverage reporting on the minimum supported Python version.
+2. **Full test suite** (`test-full` job): Runs all tests (fast + slow + integration) on Ubuntu across all Python versions (3.11-3.14) when the PR is not in draft mode or on the main branch. This comprehensive validation includes coverage reporting on the minimum supported Python version.
 
 ### Code Quality
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,9 +14,9 @@ nox.options.default_venv_backend = "uv|virtualenv"
 nox.options.sessions = ["fix", "test_fast", "serve_docs"]
 
 # Generate list of Python versions from minimum to maximum
-ALL_VERSIONS = ["3.11", "3.12", "3.13"]
+ALL_VERSIONS = ["3.11", "3.12", "3.13", "3.14"]
 MIN_VERSION = "3.11"
-MAX_VERSION = "3.13"
+MAX_VERSION = "3.14"
 PYTHON_VERSIONS = [v for v in ALL_VERSIONS if v >= MIN_VERSION and v <= MAX_VERSION]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Guillaume Tauzin", email = "gtauzin@stateful-y.io" }
 ]
 license = { text = "Apache-2.0" }
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "kedro>=1.0.0",


### PR DESCRIPTION
## Description

Add Python 3.14 to the supported versions matrix. The codebase already uses modern typing patterns and no deprecated stdlib modules, so no source code changes are needed.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): CI and packaging configuration update

## Motivation and Context

Python 3.14 is now available and all dependencies (kedro, dagster, pydantic, etc.) support it. This PR declares official support.

Fixes #61

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Changes across 8 files:
- `pyproject.toml`: `requires-python` bumped to `<3.15`, added `3.14` classifier
- `noxfile.py`: added `"3.14"` to `ALL_VERSIONS`, updated `MAX_VERSION`
- `.github/workflows/tests.yml`: added `3.14` to fast and full test matrices
- `.github/workflows/nightly.yml`: added `3.14` to matrix
- `.github/workflows/tests-versions.yml`: added `3.14` to matrix
- `.copier-answers.yml`: `max_python_version` updated to `3.14`
- `.readthedocs.yml`: bumped build Python to `3.14`
- `docs/pages/how-to/contribute.md`: updated version references in CI docs